### PR TITLE
Typo fix

### DIFF
--- a/javascript_docs_versioned_docs/version-0.0.x/api/sdk-reference/meeting-class/events.md
+++ b/javascript_docs_versioned_docs/version-0.0.x/api/sdk-reference/meeting-class/events.md
@@ -574,7 +574,7 @@ meeting.on("switch-meeting", (data) => {
 meeting.on("meeting-state-changed", (data) => {
   const { state } = data;
 
-  swtich(state){
+  switch(state){
     case 'CONNECTING':
       console.log("Meeting is Connecting" );
       break;


### PR DESCRIPTION
- Fixed typo for `switch`